### PR TITLE
Document experimental status_changed_uri

### DIFF
--- a/_includes/3-provisioning.md
+++ b/_includes/3-provisioning.md
@@ -348,12 +348,12 @@ This scheme allows sharing the same status-changed URI and secret among several 
 
 ##### Response from provider
 
-The response from the provider is ignored in this case, as this request is only a notification of some change that has already occurred on Ozwillo's side.
+The status-changed endpoint must respond with a successful status (200, 202 or 204) in a timely manner (not necessarily waiting for the underlying resources to be actually released/archived or reacquired/restored). Ozwillo will then change the instance's state from its database and it will be impossible for users to authenticate to it, and services will disappear from the store.
 
-Note that it means the provider might not be notified! When an instance is in a `STOPPED` status, it's impossible to authenticate on it. This means that a `STOPPED` instance should continue to redirect users to Ozwillo for authentication, and should treat a successful authentication as a signal that the instance actually is now `RUNNING`.
-{: .focus .soft}
+If the request times out, the Kernel will change the instance's state in its database nevertheless. Any (timely) non-successful status will abort the status change (so it can be retried later).
 
-_This situation will eventually be improved to reliably notify instances of their status change and keep it synchronized between Ozwillo and the provider. To be prepared for such a change, please respond with a successful status (200, 202 or 204) in a timely manner._
+Note that the above does not describe the current behavior. Currently, the response is ignored, and the provider might not even be notified! This means that a `STOPPED` instance should continue to redirect users to Ozwillo for authentication, and should treat a successful authentication as a signal that the instance actually is now `RUNNING` (remember that when an instance is in a `STOPPED` status, it's impossible to authenticate on it).
+{: .focus .important}
 
 #### Instance destruction
 {: #s3-destruction}

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,7 +1,7 @@
 <div id="toc">
   <section class="hidden-phone">
     <h1>Ozwillo Documentation</h1>
-    <p>v1.8</p>
+    <p>v1.12</p>
   </section>
   <section>
     <ul>
@@ -55,6 +55,7 @@
               <li><a href="#s3-2-provider-provisioning">#2 Provider provisioning</a></li>
               <li><a href="#s3-3-provider-acknowledgement">#3 Provider acknowledgement</a></li>
               <li><a href="#s3-3bis-provider-dismiss">#3bis Provider dismiss</a></li>
+              <li><a href="#s3-status-change">Instance status change</a></li>
               <li><a href="#s3-destruction">Instance destruction</a></li>
             </ul>
           </li>


### PR DESCRIPTION
There's a flaw in the workflow: we might have to change how we delete organizations (i.e. first ask to stop all instances manually, one-by-one, then only when they're all stopped can the organization be deleted – this would allow taking into account the response from providers, this is only possible when done discretely rather than in batch)

That leads me to question whether we should documented the new `status_changed_uri` field at all, or wait until we fixed the organization-deletion workflow and can provide guarantees as to whether providers will be called back.

On the pro side of documenting the current status, providers can start to adapt and fill-in the field.
